### PR TITLE
updates to use latest version of pf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.7</java.version>
 
-        <pf4j.version>2.3.0</pf4j.version>
+        <pf4j.version>2.4.0</pf4j.version>
         <spring.version>4.0.5.RELEASE</spring.version>
         <slf4j.version>1.7.5</slf4j.version>
 


### PR DESCRIPTION
My project is using the functionality to turn on and off plugins using enabled.txt and disabled.txt, but this contains a bug in version 2.3.0 that means plugins are not disabled correctly.

I am getting around this currently by excluding the transitive dependency on 2.3.0 and explicitly adding 2.4.0 in my project, but this fix would remove the need for that config,