### PR TITLE
Fix: System Extension for SpringPluginManager

### DIFF
--- a/pf4j-spring/src/main/java/org/pf4j/spring/SpringExtensionFactory.java
+++ b/pf4j-spring/src/main/java/org/pf4j/spring/SpringExtensionFactory.java
@@ -78,7 +78,7 @@ public class SpringExtensionFactory implements ExtensionFactory {
         return null;
     }
 
-    private ApplicationContext getApplicationContext(Class<T> extensionClass) {
+    private <T> ApplicationContext getApplicationContext(Class<T> extensionClass) {
         ApplicationContext applicationContext = null;
         PluginWrapper pluginWrapper = this.pluginManager.whichPlugin(extensionClass);
         if (pluginWrapper != null) { // is plugin extension

--- a/pf4j-spring/src/main/java/org/pf4j/spring/SpringExtensionFactory.java
+++ b/pf4j-spring/src/main/java/org/pf4j/spring/SpringExtensionFactory.java
@@ -15,6 +15,8 @@
  */
 package org.pf4j.spring;
 
+import java.util.Map;
+
 import org.pf4j.ExtensionFactory;
 import org.pf4j.Plugin;
 import org.pf4j.PluginManager;
@@ -61,6 +63,13 @@ public class SpringExtensionFactory implements ExtensionFactory {
                 } else if (this.pluginManager instanceof SpringPluginManager) { // is system extension and plugin manager is SpringPluginManager
                     SpringPluginManager springPluginManager = (SpringPluginManager) this.pluginManager;
                     ApplicationContext pluginContext = springPluginManager.getApplicationContext();
+                    Map<String, T> extensionBeanMap = pluginContext.getBeansOfType(extensionClass);
+                    if (!extensionBeanMap.isEmpty()) {
+                        if (extensionBeanMap.size() > 1) {
+                            log.error("There are more than 1 extension bean '{}' defined!", extensionClass.getName());
+                        }
+                        extension = extensionBeanMap.values().iterator().next();
+                    }
                     pluginContext.getAutowireCapableBeanFactory().autowireBean(extension);
                 }
             }

--- a/pf4j-spring/src/main/java/org/pf4j/spring/SpringExtensionFactory.java
+++ b/pf4j-spring/src/main/java/org/pf4j/spring/SpringExtensionFactory.java
@@ -60,8 +60,8 @@ public class SpringExtensionFactory implements ExtensionFactory {
                     pluginContext.getAutowireCapableBeanFactory().autowireBean(extension);
                 } else if (this.pluginManager instanceof SpringPluginManager) { // is system extension and plugin manager is SpringPluginManager
                     SpringPluginManager springPluginManager = (SpringPluginManager) this.pluginManager;
-                    ApplicationContext plugiContext = springPluginManager.getApplicationContext();
-                    plugiContext.getAutowireCapableBeanFactory().autowireBean(extension);
+                    ApplicationContext pluginContext = springPluginManager.getApplicationContext();
+                    pluginContext.getAutowireCapableBeanFactory().autowireBean(extension);
                 }
             }
         }


### PR DESCRIPTION
fixes for the followings:
1) system extension not the same instance as the one registered in the application context of the SpringPluginManager
2) plugin manager registering system extension as beans again even if beans already existed causing more than one instance of the same class bean to exist

Scenario as follows:
- defined a SpringPluginManager
- defined a system extension but also annotated it using Spring Framework annotations, eg. @Service, @Component, etc.
- Spring Framework will create the system extension but inside SpringExtensionFactory, it will create an instance instead of retrieving it from the Spring application context
- ExtensionInjector will also re-register already registered extensions as beans in the Spring application context