### PR TITLE
GH-55 update spring framework to version 5.2.9.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <java.version>1.8</java.version>
 
         <pf4j.version>3.2.0</pf4j.version>
-        <spring.version>4.0.5.RELEASE</spring.version>
+        <spring.version>5.2.9.RELEASE</spring.version>
         <slf4j.version>1.7.25</slf4j.version>
 
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
This just increases the version of the spring framework dependencies. Running `run-demo.sh` still succeeds.